### PR TITLE
:heavy_plus_sign: Adding required dependency: php version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
         }
     ],
     "require": {
-      "ext-json": "*"
+      "ext-json": "*",
+      "php": "^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Added the php version required to the composer file. The code used doesn't work below php7. 

More specifically scalar type hints. See here:

https://3v4l.org/Mp7GNj