### PR TITLE
Allow type overide

### DIFF
--- a/resources/views/chart/script.blade.php
+++ b/resources/views/chart/script.blade.php
@@ -24,9 +24,7 @@
             text: '{!! $chart->subtitle() !!}',
             align: '{!! $chart->subtitlePosition() !!}'
         },
-        xaxis: {
-            categories: {!! $chart->xAxis() !!}
-        },
+        xaxis:  {!! $chart->xAxis() !!},
         grid: {!! $chart->grid() !!},
         markers: {!! $chart->markers() !!},
         @if($chart->stroke())

--- a/src/LarapexChart.php
+++ b/src/LarapexChart.php
@@ -179,9 +179,9 @@ class LarapexChart
         return $this;
     }
 
-    public function setXAxis(array $categories) :LarapexChart
-    {
-        $this->xAxis = json_encode($categories);
+    public function setXAxis(array $categories, string $type = 'category') :LarapexChart
+    {   
+        $this->xAxis = json_encode(['type' => $type , 'categories' => $categories]);
         return $this;
     }
 


### PR DESCRIPTION
When using dates its sometimes useful to be able to use the datetime, type.
this change allows you to pass this type to the xaxis function and script