### PR TITLE
fix issues-40 & add improvements in default chart styles

### DIFF
--- a/config/larapex-charts.php
+++ b/config/larapex-charts.php
@@ -11,7 +11,7 @@ return [
     |
     */
 
-    'font_family' => 'Nunito',
+    'font_family' => 'Helvetica, Arial, sans-serif',
 
     'font_color' => '#373d3f',
 

--- a/src/Console/ChartMakeCommand.php
+++ b/src/Console/ChartMakeCommand.php
@@ -1,13 +1,16 @@
 <?php
 
-namespace App\Console\Commands;
+namespace ArielMejiaDev\LarapexCharts\Console;
 
+use ArielMejiaDev\LarapexCharts\Traits\WithModelStub;
 use Illuminate\Console\GeneratorCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 
 class ChartMakeCommand extends GeneratorCommand
 {
+    use WithModelStub;
+
     protected $chartTypes = [
         'Pie Chart' => 'PieChart',
         'Donut Chart' => 'DonutChart',
@@ -76,7 +79,9 @@ class ChartMakeCommand extends GeneratorCommand
             $directory = 'Json';
         }
 
-        return base_path("stubs/charts/{$directory}/{$this->selectedChart}.stub");
+        $stub = "{$directory}/{$this->selectedChart}.stub";
+
+        return $this->resolveStubPath($stub);
     }
 
     /**

--- a/src/LarapexChart.php
+++ b/src/LarapexChart.php
@@ -56,7 +56,7 @@ class LarapexChart
         $this->zoom = json_encode(['enabled' => true]);
         $this->dataLabels = json_encode(['enabled' => false]);
         $this->sparklines = json_encode(['enabled' => false]);
-        $this->fontFamily = json_encode(config('larapex-charts.font_family'));
+        $this->fontFamily = config('larapex-charts.font_family');
         $this->foreColor = config('larapex-charts.font_color');
         return $this;
     }

--- a/src/LarapexChartsServiceProvider.php
+++ b/src/LarapexChartsServiceProvider.php
@@ -22,6 +22,10 @@ class LarapexChartsServiceProvider extends ServiceProvider
         });
 
         $this->mergeConfigFrom($this->packageBasePath('config/larapex-charts.php'), 'larapex-charts');
+
+        $this->commands([
+            \ArielMejiaDev\LarapexCharts\Console\ChartMakeCommand::class,
+        ]);
     }
 
     /**
@@ -45,11 +49,9 @@ class LarapexChartsServiceProvider extends ServiceProvider
             $this->packageBasePath('config/larapex-charts.php') => base_path('config/larapex-charts.php')
         ], 'larapex-charts-config');
 
-        // Publishing commands
-        (new Filesystem)->copyDirectory(__DIR__.'/../stubs/Console/Commands', app_path('Console/Commands'));
-
-        // Publishing stubs
-        (new Filesystem)->copyDirectory(__DIR__.'/../stubs/stubs', base_path('stubs'));
+        $this->publishes([
+            $this->packageBasePath('stubs/stubs') => base_path('stubs')
+        ], 'larapex-charts-stubs');
 
     }
 

--- a/src/Traits/WithModelStub.php
+++ b/src/Traits/WithModelStub.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace ArielMejiaDev\LarapexCharts\Traits;
+
+trait WithModelStub
+{
+    protected function resolveStubPath($stub)
+    {
+        $customPath = base_path("stubs/charts/{$stub}");
+
+        $packagePath = __DIR__ . "/../stubs/charts/{$stub}";
+
+        return file_exists($customPath) ? $customPath : $packagePath;
+    }
+}

--- a/src/stubs/charts/Default/AreaChart.stub
+++ b/src/stubs/charts/Default/AreaChart.stub
@@ -1,0 +1,25 @@
+<?php
+
+namespace {{ namespace }};
+
+use ArielMejiaDev\LarapexCharts\LarapexChart;
+
+class {{ class }}
+{
+    protected $chart;
+
+    public function __construct(LarapexChart $chart)
+    {
+        $this->chart = $chart;
+    }
+
+    public function build(): \ArielMejiaDev\LarapexCharts\AreaChart
+    {
+        return $this->chart->areaChart()
+            ->setTitle('Sales during 2021.')
+            ->setSubtitle('Physical sales vs Digital sales.')
+            ->addData('Physical sales', [40, 93, 35, 42, 18, 82])
+            ->addData('Digital sales', [70, 29, 77, 28, 55, 45])
+            ->setXAxis(['January', 'February', 'March', 'April', 'May', 'June']);
+    }
+}

--- a/src/stubs/charts/Default/BarChart.stub
+++ b/src/stubs/charts/Default/BarChart.stub
@@ -1,0 +1,25 @@
+<?php
+
+namespace {{ namespace }};
+
+use ArielMejiaDev\LarapexCharts\LarapexChart;
+
+class {{ class }}
+{
+    protected $chart;
+
+    public function __construct(LarapexChart $chart)
+    {
+        $this->chart = $chart;
+    }
+
+    public function build(): \ArielMejiaDev\LarapexCharts\BarChart
+    {
+        return $this->chart->barChart()
+            ->setTitle('San Francisco vs Boston.')
+            ->setSubtitle('Wins during season 2021.')
+            ->addData('San Francisco', [6, 9, 3, 4, 10, 8])
+            ->addData('Boston', [7, 3, 8, 2, 6, 4])
+            ->setXAxis(['January', 'February', 'March', 'April', 'May', 'June']);
+    }
+}

--- a/src/stubs/charts/Default/DonutChart.stub
+++ b/src/stubs/charts/Default/DonutChart.stub
@@ -1,0 +1,24 @@
+<?php
+
+namespace {{ namespace }};
+
+use ArielMejiaDev\LarapexCharts\LarapexChart;
+
+class {{ class }}
+{
+    protected $chart;
+
+    public function __construct(LarapexChart $chart)
+    {
+        $this->chart = $chart;
+    }
+
+    public function build(): \ArielMejiaDev\LarapexCharts\DonutChart
+    {
+        return $this->chart->donutChart()
+            ->setTitle('Top 3 scorers of the team.')
+            ->setSubtitle('Season 2021.')
+            ->addData([20, 24, 30])
+            ->setLabels(['Player 7', 'Player 10', 'Player 9']);
+    }
+}

--- a/src/stubs/charts/Default/HeatMapChart.stub
+++ b/src/stubs/charts/Default/HeatMapChart.stub
@@ -1,0 +1,25 @@
+<?php
+
+namespace {{ namespace }};
+
+use ArielMejiaDev\LarapexCharts\LarapexChart;
+
+class {{ class }}
+{
+    protected $chart;
+
+    public function __construct(LarapexChart $chart)
+    {
+        $this->chart = $chart;
+    }
+
+    public function build(): \ArielMejiaDev\LarapexCharts\HeatMapChart
+    {
+        return $this->chart->heatMapChart()
+            ->setTitle('Basic radar chart')
+            ->addData('Sales', [80, 50, 30, 40, 100, 20])
+            ->addHeat('Income', [70, 10, 80, 20, 60, 40])
+            ->setMarkers(['#FFA41B', '#4F46E5'], 7, 10)
+            ->setXAxis(['January', 'February', 'March', 'April', 'May', 'June']);
+    }
+}

--- a/src/stubs/charts/Default/HorizontalBarChart.stub
+++ b/src/stubs/charts/Default/HorizontalBarChart.stub
@@ -1,0 +1,26 @@
+<?php
+
+namespace {{ namespace }};
+
+use ArielMejiaDev\LarapexCharts\LarapexChart;
+
+class {{ class }}
+{
+    protected $chart;
+
+    public function __construct(LarapexChart $chart)
+    {
+        $this->chart = $chart;
+    }
+
+    public function build(): \ArielMejiaDev\LarapexCharts\HorizontalBar
+    {
+        return $this->chart->horizontalBarChart()
+            ->setTitle('Los Angeles vs Miami.')
+            ->setSubtitle('Wins during season 2021.')
+            ->setColors(['#FFC107', '#D32F2F'])
+            ->addData('San Francisco', [6, 9, 3, 4, 10, 8])
+            ->addData('Boston', [7, 3, 8, 2, 6, 4])
+            ->setXAxis(['January', 'February', 'March', 'April', 'May', 'June']);
+    }
+}

--- a/src/stubs/charts/Default/LineChart.stub
+++ b/src/stubs/charts/Default/LineChart.stub
@@ -1,0 +1,25 @@
+<?php
+
+namespace {{ namespace }};
+
+use ArielMejiaDev\LarapexCharts\LarapexChart;
+
+class {{ class }}
+{
+    protected $chart;
+
+    public function __construct(LarapexChart $chart)
+    {
+        $this->chart = $chart;
+    }
+
+    public function build(): \ArielMejiaDev\LarapexCharts\LineChart
+    {
+        return $this->chart->lineChart()
+            ->setTitle('Sales during 2021.')
+            ->setSubtitle('Physical sales vs Digital sales.')
+            ->addData('Physical sales', [40, 93, 35, 42, 18, 82])
+            ->addData('Digital sales', [70, 29, 77, 28, 55, 45])
+            ->setXAxis(['January', 'February', 'March', 'April', 'May', 'June']);
+    }
+}

--- a/src/stubs/charts/Default/PieChart.stub
+++ b/src/stubs/charts/Default/PieChart.stub
@@ -1,0 +1,24 @@
+<?php
+
+namespace {{ namespace }};
+
+use ArielMejiaDev\LarapexCharts\LarapexChart;
+
+class {{ class }}
+{
+    protected $chart;
+
+    public function __construct(LarapexChart $chart)
+    {
+        $this->chart = $chart;
+    }
+
+    public function build(): \ArielMejiaDev\LarapexCharts\PieChart
+    {
+        return $this->chart->pieChart()
+            ->setTitle('Top 3 scorers of the team.')
+            ->setSubtitle('Season 2021.')
+            ->addData([40, 50, 30])
+            ->setLabels(['Player 7', 'Player 10', 'Player 9']);
+    }
+}

--- a/src/stubs/charts/Default/PolarAreaChart.stub
+++ b/src/stubs/charts/Default/PolarAreaChart.stub
@@ -1,0 +1,25 @@
+<?php
+
+namespace {{ namespace }};
+
+use ArielMejiaDev\LarapexCharts\LarapexChart;
+
+class {{ class }}
+{
+    protected $chart;
+
+    public function __construct(LarapexChart $chart)
+    {
+        $this->chart = $chart;
+    }
+
+    public function build(): \ArielMejiaDev\LarapexCharts\PolarAreaChart
+    {
+        return $this->chart
+            ->polarAreaChart()
+            ->setTitle('Top 3 scorers of the team.')
+            ->setSubtitle('Season 2021.')
+            ->addData([20, 24, 30])
+            ->setLabels(['Player 7', 'Player 10', 'Player 9']);
+    }
+}

--- a/src/stubs/charts/Default/RadarChart.stub
+++ b/src/stubs/charts/Default/RadarChart.stub
@@ -1,0 +1,25 @@
+<?php
+
+namespace {{ namespace }};
+
+use ArielMejiaDev\LarapexCharts\LarapexChart;
+
+class {{ class }}
+{
+    protected $chart;
+
+    public function __construct(LarapexChart $chart)
+    {
+        $this->chart = $chart;
+    }
+
+    public function build(): \ArielMejiaDev\LarapexCharts\RadarChart
+    {
+        return $this->chart->radarChart()
+            ->setTitle('Individual Player Stats.')
+            ->setSubtitle('Season 2021.')
+            ->addData('Stats', [70, 93, 78, 97, 50, 90])
+            ->setXAxis(['Pass', 'Dribble', 'Shot', 'Stamina', 'Long shots', 'Tactical'])
+            ->setMarkers(['#303F9F'], 7, 10);
+    }
+}

--- a/src/stubs/charts/Default/RadialBarChart.stub
+++ b/src/stubs/charts/Default/RadialBarChart.stub
@@ -1,0 +1,25 @@
+<?php
+
+namespace {{ namespace }};
+
+use ArielMejiaDev\LarapexCharts\LarapexChart;
+
+class {{ class }}
+{
+    protected $chart;
+
+    public function __construct(LarapexChart $chart)
+    {
+        $this->chart = $chart;
+    }
+
+    public function build(): \ArielMejiaDev\LarapexCharts\RadialChart
+    {
+        return $this->chart->radialChart()
+            ->setTitle('Passing effectiveness.')
+            ->setSubtitle('Barcelona city vs Madrid sports.')
+            ->addData([75, 60])
+            ->setLabels(['Barcelona city', 'Madrid sports'])
+            ->setColors(['#D32F2F', '#03A9F4']);
+    }
+}

--- a/src/stubs/charts/Json/AreaChart.stub
+++ b/src/stubs/charts/Json/AreaChart.stub
@@ -1,0 +1,26 @@
+<?php
+
+namespace {{ namespace }};
+
+use ArielMejiaDev\LarapexCharts\LarapexChart;
+
+class {{ class }}
+{
+    protected $chart;
+
+    public function __construct(LarapexChart $chart)
+    {
+        $this->chart = $chart;
+    }
+
+    public function build(): \Illuminate\Http\JsonResponse
+    {
+        return $this->chart->areaChart()
+            ->setTitle('Sales during 2021.')
+            ->setSubtitle('Physical sales vs Digital sales.')
+            ->addData('Physical sales', [40, 93, 35, 42, 18, 82])
+            ->addData('Digital sales', [70, 29, 77, 28, 55, 45])
+            ->setXAxis(['January', 'February', 'March', 'April', 'May', 'June'])
+            ->toJson();
+    }
+}

--- a/src/stubs/charts/Json/BarChart.stub
+++ b/src/stubs/charts/Json/BarChart.stub
@@ -1,0 +1,26 @@
+<?php
+
+namespace {{ namespace }};
+
+use ArielMejiaDev\LarapexCharts\LarapexChart;
+
+class {{ class }}
+{
+    protected $chart;
+
+    public function __construct(LarapexChart $chart)
+    {
+        $this->chart = $chart;
+    }
+
+    public function build(): \Illuminate\Http\JsonResponse
+    {
+        return $this->chart->barChart()
+            ->setTitle('San Francisco vs Boston.')
+            ->setSubtitle('Wins during season 2021.')
+            ->addData('San Francisco', [6, 9, 3, 4, 10, 8])
+            ->addData('Boston', [7, 3, 8, 2, 6, 4])
+            ->setXAxis(['January', 'February', 'March', 'April', 'May', 'June'])
+            ->toJson();
+    }
+}

--- a/src/stubs/charts/Json/DonutChart.stub
+++ b/src/stubs/charts/Json/DonutChart.stub
@@ -1,0 +1,25 @@
+<?php
+
+namespace {{ namespace }};
+
+use ArielMejiaDev\LarapexCharts\LarapexChart;
+
+class {{ class }}
+{
+    protected $chart;
+
+    public function __construct(LarapexChart $chart)
+    {
+        $this->chart = $chart;
+    }
+
+    public function build(): \Illuminate\Http\JsonResponse
+    {
+        return $this->chart->donutChart()
+            ->setTitle('Top 3 scorers of the team.')
+            ->setSubtitle('Season 2021.')
+            ->addData([20, 24, 30])
+            ->setLabels(['Player 7', 'Player 10', 'Player 9'])
+            ->toJson();
+    }
+}

--- a/src/stubs/charts/Json/HeatMapChart.stub
+++ b/src/stubs/charts/Json/HeatMapChart.stub
@@ -1,0 +1,26 @@
+<?php
+
+namespace {{ namespace }};
+
+use ArielMejiaDev\LarapexCharts\LarapexChart;
+
+class {{ class }}
+{
+    protected $chart;
+
+    public function __construct(LarapexChart $chart)
+    {
+        $this->chart = $chart;
+    }
+
+    public function build(): \Illuminate\Http\JsonResponse
+    {
+        return $this->chart->heatMapChart()
+            ->setTitle('Basic radar chart')
+            ->addData('Sales', [80, 50, 30, 40, 100, 20])
+            ->addHeat('Income', [70, 10, 80, 20, 60, 40])
+            ->setMarkers(['#FFA41B', '#4F46E5'], 7, 10)
+            ->setXAxis(['January', 'February', 'March', 'April', 'May', 'June'])
+            ->toJson();
+    }
+}

--- a/src/stubs/charts/Json/HorizontalBarChart.stub
+++ b/src/stubs/charts/Json/HorizontalBarChart.stub
@@ -1,0 +1,27 @@
+<?php
+
+namespace {{ namespace }};
+
+use ArielMejiaDev\LarapexCharts\LarapexChart;
+
+class {{ class }}
+{
+    protected $chart;
+
+    public function __construct(LarapexChart $chart)
+    {
+        $this->chart = $chart;
+    }
+
+    public function build(): \Illuminate\Http\JsonResponse
+    {
+        return $this->chart->horizontalBarChart()
+            ->setTitle('Los Angeles vs Miami.')
+            ->setSubtitle('Wins during season 2021.')
+            ->setColors(['#FFC107', '#D32F2F'])
+            ->addData('San Francisco', [6, 9, 3, 4, 10, 8])
+            ->addData('Boston', [7, 3, 8, 2, 6, 4])
+            ->setXAxis(['January', 'February', 'March', 'April', 'May', 'June'])
+            ->toJson();
+    }
+}

--- a/src/stubs/charts/Json/LineChart.stub
+++ b/src/stubs/charts/Json/LineChart.stub
@@ -1,0 +1,26 @@
+<?php
+
+namespace {{ namespace }};
+
+use ArielMejiaDev\LarapexCharts\LarapexChart;
+
+class {{ class }}
+{
+    protected $chart;
+
+    public function __construct(LarapexChart $chart)
+    {
+        $this->chart = $chart;
+    }
+
+    public function build(): \Illuminate\Http\JsonResponse
+    {
+        return $this->chart->lineChart()
+            ->setTitle('Sales during 2021.')
+            ->setSubtitle('Physical sales vs Digital sales.')
+            ->addData('Physical sales', [40, 93, 35, 42, 18, 82])
+            ->addData('Digital sales', [70, 29, 77, 28, 55, 45])
+            ->setXAxis(['January', 'February', 'March', 'April', 'May', 'June'])
+            ->toJson();
+    }
+}

--- a/src/stubs/charts/Json/PieChart.stub
+++ b/src/stubs/charts/Json/PieChart.stub
@@ -1,0 +1,25 @@
+<?php
+
+namespace {{ namespace }};
+
+use ArielMejiaDev\LarapexCharts\LarapexChart;
+
+class {{ class }}
+{
+    protected $chart;
+
+    public function __construct(LarapexChart $chart)
+    {
+        $this->chart = $chart;
+    }
+
+    public function build(): \Illuminate\Http\JsonResponse
+    {
+        return $this->chart->pieChart()
+            ->setTitle('Top 3 scorers of the team.')
+            ->setSubtitle('Season 2021.')
+            ->addData([40, 50, 30])
+            ->setLabels(['Player 7', 'Player 10', 'Player 9'])
+            ->toJson();
+    }
+}

--- a/src/stubs/charts/Json/PolarAreaChart.stub
+++ b/src/stubs/charts/Json/PolarAreaChart.stub
@@ -1,0 +1,26 @@
+<?php
+
+namespace {{ namespace }};
+
+use ArielMejiaDev\LarapexCharts\LarapexChart;
+
+class {{ class }}
+{
+    protected $chart;
+
+    public function __construct(LarapexChart $chart)
+    {
+        $this->chart = $chart;
+    }
+
+    public function build(): \Illuminate\Http\JsonResponse
+    {
+        return $this->chart
+            ->polarAreaChart()
+            ->setTitle('Top 3 scorers of the team.')
+            ->setSubtitle('Season 2021.')
+            ->addData([20, 24, 30])
+            ->setLabels(['Player 7', 'Player 10', 'Player 9'])
+            ->toJson();
+    }
+}

--- a/src/stubs/charts/Json/RadarChart.stub
+++ b/src/stubs/charts/Json/RadarChart.stub
@@ -1,0 +1,26 @@
+<?php
+
+namespace {{ namespace }};
+
+use ArielMejiaDev\LarapexCharts\LarapexChart;
+
+class {{ class }}
+{
+    protected $chart;
+
+    public function __construct(LarapexChart $chart)
+    {
+        $this->chart = $chart;
+    }
+
+    public function build(): \Illuminate\Http\JsonResponse
+    {
+        return $this->chart->radarChart()
+            ->setTitle('Individual Player Stats.')
+            ->setSubtitle('Season 2021.')
+            ->addData('Stats', [70, 93, 78, 97, 50, 90])
+            ->setXAxis(['Pass', 'Dribble', 'Shot', 'Stamina', 'Long shots', 'Tactical'])
+            ->setMarkers(['#303F9F'], 7, 10)
+            ->toJson();
+    }
+}

--- a/src/stubs/charts/Json/RadialBarChart.stub
+++ b/src/stubs/charts/Json/RadialBarChart.stub
@@ -1,0 +1,26 @@
+<?php
+
+namespace {{ namespace }};
+
+use ArielMejiaDev\LarapexCharts\LarapexChart;
+
+class {{ class }}
+{
+    protected $chart;
+
+    public function __construct(LarapexChart $chart)
+    {
+        $this->chart = $chart;
+    }
+
+    public function build(): \Illuminate\Http\JsonResponse
+    {
+        return $this->chart->radialChart()
+            ->setTitle('Passing effectiveness.')
+            ->setSubtitle('Barcelona city vs Madrid sports.')
+            ->addData([75, 60])
+            ->setLabels(['Barcelona city', 'Madrid sports'])
+            ->setColors(['#D32F2F', '#03A9F4'])
+            ->toJson();
+    }
+}

--- a/src/stubs/charts/Vue/AreaChart.stub
+++ b/src/stubs/charts/Vue/AreaChart.stub
@@ -1,0 +1,26 @@
+<?php
+
+namespace {{ namespace }};
+
+use ArielMejiaDev\LarapexCharts\LarapexChart;
+
+class {{ class }}
+{
+    protected $chart;
+
+    public function __construct(LarapexChart $chart)
+    {
+        $this->chart = $chart;
+    }
+
+    public function build(): array
+    {
+        return $this->chart->areaChart()
+            ->setTitle('Sales during 2021.')
+            ->setSubtitle('Physical sales vs Digital sales.')
+            ->addData('Physical sales', [40, 93, 35, 42, 18, 82])
+            ->addData('Digital sales', [70, 29, 77, 28, 55, 45])
+            ->setXAxis(['January', 'February', 'March', 'April', 'May', 'June'])
+            ->toVue();
+    }
+}

--- a/src/stubs/charts/Vue/BarChart.stub
+++ b/src/stubs/charts/Vue/BarChart.stub
@@ -1,0 +1,26 @@
+<?php
+
+namespace {{ namespace }};
+
+use ArielMejiaDev\LarapexCharts\LarapexChart;
+
+class {{ class }}
+{
+    protected $chart;
+
+    public function __construct(LarapexChart $chart)
+    {
+        $this->chart = $chart;
+    }
+
+    public function build(): array
+    {
+        return $this->chart->barChart()
+            ->setTitle('San Francisco vs Boston.')
+            ->setSubtitle('Wins during season 2021.')
+            ->addData('San Francisco', [6, 9, 3, 4, 10, 8])
+            ->addData('Boston', [7, 3, 8, 2, 6, 4])
+            ->setXAxis(['January', 'February', 'March', 'April', 'May', 'June'])
+            ->toVue();
+    }
+}

--- a/src/stubs/charts/Vue/DonutChart.stub
+++ b/src/stubs/charts/Vue/DonutChart.stub
@@ -1,0 +1,25 @@
+<?php
+
+namespace {{ namespace }};
+
+use ArielMejiaDev\LarapexCharts\LarapexChart;
+
+class {{ class }}
+{
+    protected $chart;
+
+    public function __construct(LarapexChart $chart)
+    {
+        $this->chart = $chart;
+    }
+
+    public function build(): array
+    {
+        return $this->chart->donutChart()
+            ->setTitle('Top 3 scorers of the team.')
+            ->setSubtitle('Season 2021.')
+            ->addData([20, 24, 30])
+            ->setLabels(['Player 7', 'Player 10', 'Player 9'])
+            ->toVue();
+    }
+}

--- a/src/stubs/charts/Vue/HeatMapChart.stub
+++ b/src/stubs/charts/Vue/HeatMapChart.stub
@@ -1,0 +1,26 @@
+<?php
+
+namespace {{ namespace }};
+
+use ArielMejiaDev\LarapexCharts\LarapexChart;
+
+class {{ class }}
+{
+    protected $chart;
+
+    public function __construct(LarapexChart $chart)
+    {
+        $this->chart = $chart;
+    }
+
+    public function build(): array
+    {
+        return $this->chart->heatMapChart()
+            ->setTitle('Basic radar chart')
+            ->addData('Sales', [80, 50, 30, 40, 100, 20])
+            ->addHeat('Income', [70, 10, 80, 20, 60, 40])
+            ->setMarkers(['#FFA41B', '#4F46E5'], 7, 10)
+            ->setXAxis(['January', 'February', 'March', 'April', 'May', 'June'])
+            ->toVue();
+    }
+}

--- a/src/stubs/charts/Vue/HorizontalBarChart.stub
+++ b/src/stubs/charts/Vue/HorizontalBarChart.stub
@@ -1,0 +1,27 @@
+<?php
+
+namespace {{ namespace }};
+
+use ArielMejiaDev\LarapexCharts\LarapexChart;
+
+class {{ class }}
+{
+    protected $chart;
+
+    public function __construct(LarapexChart $chart)
+    {
+        $this->chart = $chart;
+    }
+
+    public function build(): array
+    {
+        return $this->chart->horizontalBarChart()
+            ->setTitle('Los Angeles vs Miami.')
+            ->setSubtitle('Wins during season 2021.')
+            ->setColors(['#FFC107', '#D32F2F'])
+            ->addData('San Francisco', [6, 9, 3, 4, 10, 8])
+            ->addData('Boston', [7, 3, 8, 2, 6, 4])
+            ->setXAxis(['January', 'February', 'March', 'April', 'May', 'June'])
+            ->toVue();
+    }
+}

--- a/src/stubs/charts/Vue/LineChart.stub
+++ b/src/stubs/charts/Vue/LineChart.stub
@@ -1,0 +1,26 @@
+<?php
+
+namespace {{ namespace }};
+
+use ArielMejiaDev\LarapexCharts\LarapexChart;
+
+class {{ class }}
+{
+    protected $chart;
+
+    public function __construct(LarapexChart $chart)
+    {
+        $this->chart = $chart;
+    }
+
+    public function build(): array
+    {
+        return $this->chart->lineChart()
+            ->setTitle('Sales during 2021.')
+            ->setSubtitle('Physical sales vs Digital sales.')
+            ->addData('Physical sales', [40, 93, 35, 42, 18, 82])
+            ->addData('Digital sales', [70, 29, 77, 28, 55, 45])
+            ->setXAxis(['January', 'February', 'March', 'April', 'May', 'June'])
+            ->toVue();
+    }
+}

--- a/src/stubs/charts/Vue/PieChart.stub
+++ b/src/stubs/charts/Vue/PieChart.stub
@@ -1,0 +1,25 @@
+<?php
+
+namespace {{ namespace }};
+
+use ArielMejiaDev\LarapexCharts\LarapexChart;
+
+class {{ class }}
+{
+    protected $chart;
+
+    public function __construct(LarapexChart $chart)
+    {
+        $this->chart = $chart;
+    }
+
+    public function build(): array
+    {
+        return $this->chart->pieChart()
+            ->setTitle('Top 3 scorers of the team.')
+            ->setSubtitle('Season 2021.')
+            ->addData([40, 50, 30])
+            ->setLabels(['Player 7', 'Player 10', 'Player 9'])
+            ->toVue();
+    }
+}

--- a/src/stubs/charts/Vue/PolarAreaChart.stub
+++ b/src/stubs/charts/Vue/PolarAreaChart.stub
@@ -1,0 +1,26 @@
+<?php
+
+namespace {{ namespace }};
+
+use ArielMejiaDev\LarapexCharts\LarapexChart;
+
+class {{ class }}
+{
+    protected $chart;
+
+    public function __construct(LarapexChart $chart)
+    {
+        $this->chart = $chart;
+    }
+
+    public function build(): array
+    {
+        return $this->chart
+            ->polarAreaChart()
+            ->setTitle('Top 3 scorers of the team.')
+            ->setSubtitle('Season 2021.')
+            ->addData([20, 24, 30])
+            ->setLabels(['Player 7', 'Player 10', 'Player 9'])
+            ->toVue();
+    }
+}

--- a/src/stubs/charts/Vue/RadarChart.stub
+++ b/src/stubs/charts/Vue/RadarChart.stub
@@ -1,0 +1,26 @@
+<?php
+
+namespace {{ namespace }};
+
+use ArielMejiaDev\LarapexCharts\LarapexChart;
+
+class {{ class }}
+{
+    protected $chart;
+
+    public function __construct(LarapexChart $chart)
+    {
+        $this->chart = $chart;
+    }
+
+    public function build(): array
+    {
+        return $this->chart->radarChart()
+            ->setTitle('Individual Player Stats.')
+            ->setSubtitle('Season 2021.')
+            ->addData('Stats', [70, 93, 78, 97, 50, 90])
+            ->setXAxis(['Pass', 'Dribble', 'Shot', 'Stamina', 'Long shots', 'Tactical'])
+            ->setMarkers(['#303F9F'], 7, 10)
+            ->toVue();
+    }
+}

--- a/src/stubs/charts/Vue/RadialBarChart.stub
+++ b/src/stubs/charts/Vue/RadialBarChart.stub
@@ -1,0 +1,26 @@
+<?php
+
+namespace {{ namespace }};
+
+use ArielMejiaDev\LarapexCharts\LarapexChart;
+
+class {{ class }}
+{
+    protected $chart;
+
+    public function __construct(LarapexChart $chart)
+    {
+        $this->chart = $chart;
+    }
+
+    public function build(): array
+    {
+        return $this->chart->radialChart()
+            ->setTitle('Passing effectiveness.')
+            ->setSubtitle('Barcelona city vs Madrid sports.')
+            ->addData([75, 60])
+            ->setLabels(['Barcelona city', 'Madrid sports'])
+            ->setColors(['#D32F2F', '#03A9F4'])
+            ->toVue();
+    }
+}


### PR DESCRIPTION
It fixes this issues:

- The stubs and commands are published by the service provider each time the application is started
- It should be only published on vendor:publish. No every time.
- It will break on anything hosted on serverless (by publishing files on every request).



reference here: https://github.com/ArielMejiaDev/larapex-charts/issues/40