### PR TITLE
fix confusing syntax on set grid method

### DIFF
--- a/.idea/larapex-charts.iml
+++ b/.idea/larapex-charts.iml
@@ -111,6 +111,13 @@
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/stopwatch" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/string" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/ramsey/collection" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/polyfill-php81" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/laravel/serializable-closure" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/dflydev/dot-access-data" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/pimple/pimple" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/nette/schema" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/league/config" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/nette/utils" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -105,9 +105,16 @@
       <path value="$PROJECT_DIR$/vendor/symfony/stopwatch" />
       <path value="$PROJECT_DIR$/vendor/symfony/string" />
       <path value="$PROJECT_DIR$/vendor/ramsey/collection" />
+      <path value="$PROJECT_DIR$/vendor/symfony/polyfill-php81" />
+      <path value="$PROJECT_DIR$/vendor/laravel/serializable-closure" />
+      <path value="$PROJECT_DIR$/vendor/dflydev/dot-access-data" />
+      <path value="$PROJECT_DIR$/vendor/pimple/pimple" />
+      <path value="$PROJECT_DIR$/vendor/nette/schema" />
+      <path value="$PROJECT_DIR$/vendor/league/config" />
+      <path value="$PROJECT_DIR$/vendor/nette/utils" />
     </include_path>
   </component>
-  <component name="PhpProjectSharedConfiguration" php_language_level="7">
+  <component name="PhpProjectSharedConfiguration">
     <option name="suggestChangeDefaultLanguageLevel" value="false" />
   </component>
   <component name="PhpUnit">

--- a/src/LarapexChart.php
+++ b/src/LarapexChart.php
@@ -196,17 +196,13 @@ class LarapexChart
         return $this;
     }
 
-    public function setGrid($transparent = true, $color = '#e5e5e5', $opacity = 0.1) :LarapexChart
+    public function setGrid($color = '#e5e5e5', $opacity = 0.1) :LarapexChart
     {
-        if($transparent) {
-            $this->grid = json_encode(['show' => true]);
-            return $this;
-        }
-
         $this->grid = json_encode([
+            'show' => true,
             'row' => [
                 'colors' => [$color, 'transparent'],
-                'opacity' => $opacity ? $opacity : 0.5
+                'opacity' => $opacity,
             ],
         ]);
 

--- a/tests/Unit/ChartsTest.php
+++ b/tests/Unit/ChartsTest.php
@@ -2,12 +2,15 @@
 
 use ArielMejiaDev\LarapexCharts\LarapexChart;
 use ArielMejiaDev\LarapexCharts\Tests\TestCase;
+use Illuminate\Support\Facades\Artisan;
 
 class ChartsTest extends TestCase
 {
     /** @test */
     public function it_tests_larapex_charts_install_add_chart_stubs()
     {
+        Artisan::call('vendor:publish --all');
+
         $chartTypes = collect([
             'PieChart',
             'DonutChart',
@@ -34,10 +37,6 @@ class ChartsTest extends TestCase
                 file_exists(base_path("stubs/charts/Json/{$chart}.stub"))
             );
         });
-
-        $this->assertTrue(
-            file_exists(app_path('Console/Commands/ChartMakeCommand.php'))
-        );
     }
 
     /** @test */


### PR DESCRIPTION
it fixes an issue related to a pour readable method.

Charts by default would work without grid.

To add a default grid (gray and some opacity... plays really well with Tailwindui styles)

php
```
$chart->areaChart()->setGrid();
```

To customize the grid color and opacity you can pass params to the grid setter:

php
```
$chart->areaChart()->setGrid('#93c5fd', 0.2);
```