### PR TITLE
Expliciting end of chart options object

### DIFF
--- a/stubs/resources/views/chart/script.blade.php
+++ b/stubs/resources/views/chart/script.blade.php
@@ -35,7 +35,7 @@
         @if($chart->stroke())
             stroke: {!! $chart->stroke() !!},
         @endif
-    }
+    };
 
     var chart = new ApexCharts(document.querySelector("#{!! $chart->id() !!}"), options);
     chart.render();


### PR DESCRIPTION
hello guys, im using your package along aside with laravel-page-speed, this package remove all whitespaces to reduce the size of html payload, it requires each javascript end of objects is in explicity mode.

i believe that modification not affects the normal function of the package.

im at your disposal.