### PR TITLE
added .setExtraOptions

### DIFF
--- a/src/Traits/ComplexChartDataAggregator.php
+++ b/src/Traits/ComplexChartDataAggregator.php
@@ -4,14 +4,19 @@ namespace ArielMejiaDev\LarapexCharts\Traits;
 
 trait ComplexChartDataAggregator
 {
-    public function addData(string $name, array $data) :self
+    public function addData(string $name, array $data, string $type = null) :self
     {
         $this->dataset = json_decode($this->dataset);
 
-        $this->dataset[] = [
+        $newData =  [
             'name' => $name,
             'data' => $data
         ];
+
+        if ($type)
+            $newData['type'] = $type;
+
+        $this->dataset[] = $newData;
 
         $this->dataset = json_encode($this->dataset);
 


### PR DESCRIPTION
To get serious use out of the apexcharts library, it was necessary to expose the complete range of options.

It is now possible to create much more capable graphs, by passing an apexcharts style `options` argument to `setExtraOptions()`, e.g.:

```php
        $options = [
            'chart' => [
                'stacked' => true,
            ],
            'fill' => [
                'opacity' => 0.5,
            ],
            'tooltip' => [
                'fixed' => [
                    'enabled' => true,
                    'position' => 'topRight',
                ],
                'followCursor' => true,
            ],
            'plotOptions' => [
                'bar' => [
                    'borderRadius' => 0,
                    'stroke' => [
                        'width' => 5,
                    ],
                ],
                'line' => [
                    'stroke' => [
                        'width' => 8,
                    ]
                ],

            ],
        ];

        return $this->withMeta([
            'chart' => $this->chart->lineChart()
                ->setTitle('Scraping Delay')
                ->addData('minutes', $result->pluck('minutes')->map(fn ($v) => round($v))->all(), 'line')
                ->addData('impressions', $result->pluck('latest_impressions')->all(), 'column')
                ->addData('articles', $result->pluck('latest_articles')->all(), 'column')
                ->addData('failed', $result->map(fn ($row) => $row->failed < $row->minutes ? $row->failed : 0)->map(fn ($v) => round($v))->all(), 'area')
                ->setLabels($result->pluck('name')->all())
                ->setStroke(['curve' => 'stepline'])
                ->setFontColor('currentColor')
                ->setSparkline()
                ->setWidth(512)
                ->setHeight(212)
                ->setExtraOptions($options)
                ->toVue(),
        ]);
```