### PR TITLE
- ignoring the .idea-folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor
 composer.lock
 .phpunit.result.cache
 coverage
+.idea


### PR DESCRIPTION
after check out the project with phpstorm and install the composer packages, a .idea-folder was created. it should not be committed.