### PR TITLE
fix to show labels

### DIFF
--- a/stubs/resources/views/chart/script.blade.php
+++ b/stubs/resources/views/chart/script.blade.php
@@ -21,6 +21,7 @@
         series: {!! $chart->dataset() !!},
         dataLabels: {!! $chart->dataLabels() !!},
         @if($chart->labels())
+        
             labels: {!! json_encode($chart->labels(), true) !!},
         @endif
         title: {


### PR DESCRIPTION
I just put a space inside IF condition on **stubs/resources/views/chart/script.blade.php**

```
@if($chart->labels())
        
    labels: {!! json_encode($chart->labels(), true) !!},
@endif
```
Its to fix the fact that labels not appears like configured with setLabels(). 

![image](https://github.com/user-attachments/assets/241d4dd6-4ca9-48b1-a24c-a8f7a677fcd1)